### PR TITLE
feat: add Hono AWS adapter for serverless deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,7 @@ yarn-error.log*
 # ui
 dist/
 
+.nucel-build
+
 # IDE
 .idea/

--- a/apps/github-webhook-server/src/app.ts
+++ b/apps/github-webhook-server/src/app.ts
@@ -1,0 +1,192 @@
+import { config } from './config.js';
+import { Hono } from 'hono';
+import { cors } from 'hono/cors';
+import { logger } from 'hono/logger';
+import { NucelGitHubApp } from '@nucel.cloud/github-app';
+import { db, githubInstallation, project, deployment } from '@nucel/database';
+import { eq, and } from 'drizzle-orm';
+import { nanoid } from 'nanoid';
+import { webhookRoutes } from './routes/webhooks.js';
+import { apiRoutes } from './routes/api.js';
+import { healthRoutes } from './routes/health.js';
+
+const app = new Hono();
+
+// Initialize GitHub App
+const githubApp = new NucelGitHubApp({
+  appId: config.github.appId,
+  privateKey: config.github.privateKey,
+  webhookSecret: config.github.webhookSecret,
+  oauth: config.github.oauth,
+});
+
+// Middleware
+app.use('*', logger());
+app.use('*', cors({
+  origin: config.isDevelopment ? '*' : config.allowedOrigins,
+  credentials: true,
+}));
+
+// Routes
+app.route('/health', healthRoutes);
+app.route('/api', apiRoutes(githubApp));
+app.route('/webhooks', webhookRoutes(githubApp));
+
+// Root endpoint
+app.get('/', (c) => {
+  return c.json({
+    name: 'Nucel GitHub Webhook Server',
+    version: '0.1.0',
+    endpoints: {
+      health: '/health',
+      webhooks: '/webhooks/github',
+      api: {
+        installations: '/api/installations',
+        repositories: '/api/repositories',
+        deployment: '/api/deploy',
+      }
+    }
+  });
+});
+
+// 404 handler
+app.notFound((c) => {
+  return c.json({ error: 'Not Found' }, 404);
+});
+
+// Error handler
+app.onError((err, c) => {
+  console.error('Server error:', err);
+  return c.json({ error: 'Internal Server Error' }, 500);
+});
+
+// Register webhook handlers
+githubApp.on('installation', async ({ payload }) => {
+  console.log(`[GitHub Webhook] New installation event: ${payload.action}`);
+  console.log(`[GitHub Webhook] Installation ID: ${payload.installation.id}`);
+  
+  // Type guard for account
+  if (!payload.installation.account) {
+    console.error(`[GitHub Webhook] Installation missing account information`);
+    return;
+  }
+
+  // Get account login - handle both User and Organization types
+  const accountLogin = 'login' in payload.installation.account 
+    ? payload.installation.account.login 
+    : payload.installation.account.name;
+    
+  // Determine account type
+  const accountType = 'type' in payload.installation.account 
+    ? payload.installation.account.type 
+    : 'Organization';
+
+  console.log(`[GitHub Webhook] Account: ${accountLogin} (${accountType})`);
+
+  if (payload.action === 'created' || payload.action === 'new_permissions_accepted') {
+    try {
+      // Save the installation with userId as 'pending' - will be claimed during onboarding
+      await db.insert(githubInstallation).values({
+        id: nanoid(),
+        installationId: payload.installation.id,
+        userId: null, // Will be claimed when user refreshes onboarding page
+        accountLogin: accountLogin,
+        accountType: accountType,
+        accountAvatarUrl: payload.installation.account.avatar_url || null,
+        targetType: payload.installation.target_type || 'User',
+        repositorySelection: payload.installation.repository_selection || 'all',
+        permissions: JSON.stringify(payload.installation.permissions || {}),
+        events: JSON.stringify(payload.installation.events || []),
+        installedAt: new Date(payload.installation.created_at),
+        updatedAt: new Date(payload.installation.updated_at),
+      });
+      
+      console.log(`[GitHub Webhook] ✅ Saved installation ${payload.installation.id} as pending`);
+    } catch (error) {
+      console.error(`[GitHub Webhook] ❌ Failed to save installation:`, error);
+    }
+  }
+  
+  if (payload.action === 'deleted') {
+    console.log(`[GitHub Webhook] Installation ${payload.installation.id} was deleted`);
+    // Optionally mark installation as deleted in database
+  }
+});
+
+githubApp.on('installation_repositories', async ({ payload }) => {
+  console.log(`[GitHub Webhook] Installation repositories updated for ${payload.installation.id}`);
+  console.log(`[GitHub Webhook] Action: ${payload.action}`);
+  
+  if (payload.repositories_added && payload.repositories_added.length > 0) {
+    console.log(`[GitHub Webhook] Added repositories:`, payload.repositories_added.map(r => r.full_name));
+  }
+  
+  if (payload.repositories_removed && payload.repositories_removed.length > 0) {
+    console.log(`[GitHub Webhook] Removed repositories:`, payload.repositories_removed.map(r => r.full_name));
+  }
+});
+
+githubApp.on('push', async ({ payload }) => {
+  console.log(`📌 Push to ${payload.repository.full_name}`);
+  
+  const branch = payload.ref.replace('refs/heads/', '');
+  
+  // Check if this push is to a project's default branch
+  const projects = await db
+    .select()
+    .from(project)
+    .where(
+      and(
+        eq(project.githubRepo, payload.repository.full_name),
+        eq(project.githubInstallationId, payload.installation?.id || 0)
+      )
+    )
+    .limit(1);
+  
+  if (projects.length === 0) {
+    console.log(`[GitHub Webhook] No project found for ${payload.repository.full_name}`);
+    return;
+  }
+  
+  const proj = projects[0];
+  
+  if (!proj || branch !== proj.defaultBranch) {
+    console.log(`[GitHub Webhook] Push to non-default branch ${branch}, skipping`);
+    return;
+  }
+  
+  // Create deployment record
+  await db.insert(deployment).values({
+    id: nanoid(),
+    projectId: proj.id,
+    commitSha: payload.after,
+    commitMessage: payload.head_commit?.message || '',
+    commitAuthor: payload.pusher.name,
+    branch,
+    status: 'pending',
+    deploymentType: 'commit',
+    environment: 'production',
+    createdAt: new Date(),
+  });
+  
+  console.log(`[GitHub Webhook] Created deployment for ${payload.repository.full_name}`);
+});
+
+githubApp.on('pull_request', async ({ payload }) => {
+  console.log(`🔀 PR ${payload.action} in ${payload.repository.full_name}`);
+  // Handle pull request events
+});
+
+githubApp.on('issue_comment', async ({ payload }) => {
+  console.log(`💬 Comment in ${payload.repository.full_name}`);
+  // Handle issue comments
+});
+
+githubApp.on('deployment', async ({ payload }) => {
+  console.log(`🚀 Deployment in ${payload.repository.full_name}`);
+  // Handle deployment events
+});
+
+// Export for Lambda handler
+export default app;
+export { app, githubApp };

--- a/apps/hono/package.json
+++ b/apps/hono/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "hono-app",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "hono": "^4.7.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.20.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/apps/hono/src/index.ts
+++ b/apps/hono/src/index.ts
@@ -1,0 +1,86 @@
+import { Hono } from 'hono';
+import { cors } from 'hono/cors';
+import { logger } from 'hono/logger';
+
+const app = new Hono();
+
+// Middleware
+app.use('*', logger());
+app.use('*', cors());
+
+// Routes
+app.get('/', (c) => {
+  return c.json({
+    message: 'Hello from Hono on AWS Lambda!',
+    timestamp: new Date().toISOString(),
+    path: c.req.path,
+    method: c.req.method,
+  });
+});
+
+app.get('/api/users', (c) => {
+  return c.json({
+    users: [
+      { id: 1, name: 'Alice' },
+      { id: 2, name: 'Bob' },
+      { id: 3, name: 'Charlie' },
+    ],
+  });
+});
+
+app.get('/api/users/:id', (c) => {
+  const id = c.req.param('id');
+  return c.json({
+    user: { id, name: `User ${id}` },
+  });
+});
+
+app.post('/api/echo', async (c) => {
+  const body = await c.req.json();
+  return c.json({
+    echo: body,
+    timestamp: new Date().toISOString(),
+  });
+});
+
+app.get('/health', (c) => {
+  return c.json({
+    status: 'healthy',
+    uptime: process.uptime(),
+    memory: process.memoryUsage(),
+  });
+});
+
+// Stream example (text streaming)
+app.get('/api/stream', async (c) => {
+  c.header('Content-Type', 'text/plain');
+  c.header('Transfer-Encoding', 'chunked');
+  
+  return c.text('Stream chunk 1\nStream chunk 2\nStream chunk 3\nStream chunk 4\nStream chunk 5\n');
+});
+
+// 404 handler
+app.notFound((c) => {
+  return c.json({ error: 'Not Found', path: c.req.path }, 404);
+});
+
+// Error handler
+app.onError((err, c) => {
+  console.error('Error:', err);
+  return c.json({ error: 'Internal Server Error' }, 500);
+});
+
+// Export for Lambda
+export default app;
+
+// For local development
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const port = process.env.PORT || 3000;
+  console.log(`Server running on http://localhost:${port}`);
+  
+  const { serve } = await import('@hono/node-server');
+  serve({
+    fetch: app.fetch,
+    port: Number(port),
+  });
+}

--- a/apps/hono/tsconfig.json
+++ b/apps/hono/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/react-router/react-router.config.ts
+++ b/apps/react-router/react-router.config.ts
@@ -1,5 +1,5 @@
 import type { Config } from "@react-router/dev/config";
-import reactRouterNucelAwsAdapter from "@donswayo/pulumi-react-router-aws/adapter";
+import reactRouterNucelAwsAdapter from "@nucel.cloud/react-router-aws/adapter";
 
 const adapter = reactRouterNucelAwsAdapter({
   out: '.nucel-build',

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nucel.cloud/cli",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "The open-source deployment platform for modern web apps",
   "type": "module",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nucel.cloud/cli",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "The open-source deployment platform for modern web apps",
   "type": "module",
   "bin": {

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -7,6 +7,7 @@ import { buildProject } from '../utils/build.js';
 import { createNextJsProgram } from '../programs/nextjs.js';
 import { createSvelteKitProgram } from '../programs/sveltekit.js';
 import { createReactRouterProgram } from '../programs/react-router.js';
+import { createHonoProgram } from '../programs/hono.js';
 import { loadConfig } from '../config/loader.js';
 import type { ProjectConfig } from '../config/types.js';
 import { initializePulumiStack, refreshStack, displayPreviewResults, displayDeploymentResults } from '../utils/deployment.js';
@@ -97,6 +98,9 @@ export async function deploy(options: DeployOptions) {
       break;
     case 'react-router':
       pulumiProgram = createReactRouterProgram(config);
+      break;
+    case 'hono':
+      pulumiProgram = createHonoProgram(config);
       break;
     default:
       throw new Error(`Unsupported framework: ${config.framework}`);

--- a/packages/cli/src/config/framework-configs.ts
+++ b/packages/cli/src/config/framework-configs.ts
@@ -33,6 +33,13 @@ export const FRAMEWORK_CONFIGS: Record<Framework, FrameworkConfig> = {
     configFiles: ['react-router.config.ts', 'react-router.config.js'],
     dependencies: ['react-router', '@react-router/dev'],
   },
+  hono: {
+    buildCommand: 'npm run build',
+    outputDirectory: '.nucel-build',
+    envPrefixes: ['HONO_', 'NUCEL_'],
+    configFiles: [],
+    dependencies: ['hono'],
+  },
   unknown: {
     buildCommand: 'npm run build',
     outputDirectory: 'dist',

--- a/packages/cli/src/config/types.ts
+++ b/packages/cli/src/config/types.ts
@@ -1,10 +1,10 @@
 import { z } from 'zod';
 
-export type Framework = 'nextjs' | 'sveltekit' | 'react-router' | 'unknown';
+export type Framework = 'nextjs' | 'sveltekit' | 'react-router' | 'hono' | 'unknown';
 
 export const NucelConfigSchema = z.object({
   name: z.string().optional(),
-  framework: z.enum(['nextjs', 'sveltekit', 'react-router']).optional(),
+  framework: z.enum(['nextjs', 'sveltekit', 'react-router', 'hono']).optional(),
   buildCommand: z.string().optional(),
   outputDirectory: z.string().optional(),
   environment: z.record(z.string()).optional(),

--- a/packages/cli/src/programs/hono.ts
+++ b/packages/cli/src/programs/hono.ts
@@ -55,12 +55,12 @@ export function createHonoProgram(config: ProjectConfig) {
             minify: true,
             sourcemap: false,
             external: [],
-            streaming: false,
+            streaming: true,
           },
           {
             bundle: true,
             minify: true,
-            streaming: false,
+            streaming: true,
           }
         );
         

--- a/packages/cli/src/programs/hono.ts
+++ b/packages/cli/src/programs/hono.ts
@@ -1,0 +1,96 @@
+import { HonoNucelAws } from '@nucel.cloud/hono-aws';
+import { buildHonoForAws } from '@nucel.cloud/hono-aws/adapter';
+import { ProjectConfig } from '../config/types.js';
+import * as path from 'path';
+import * as fs from 'fs';
+import chalk from 'chalk';
+
+export function createHonoProgram(config: ProjectConfig) {
+  return async () => {
+    const projectRoot = process.cwd();
+    
+    console.log(chalk.cyan('[Hono] Starting deployment...'));
+    console.log(chalk.gray(`  Working directory: ${projectRoot}`));
+    console.log(chalk.gray(`  Config output dir: ${config.outputDirectory || 'dist'}`));
+    
+    const projectName = config.name.replace(/[^a-zA-Z0-9-]/g, '-');
+    
+    let buildPath: string | null = null;
+    const nucelBuildPath = path.join(projectRoot, '.nucel-build');
+    const standardBuildPath = path.join(projectRoot, config.outputDirectory || 'dist');
+    
+    // Check if .nucel-build exists (already prepared for AWS)
+    if (fs.existsSync(path.join(nucelBuildPath, 'server'))) {
+      // Already have AWS-ready build
+      buildPath = nucelBuildPath;
+      console.log(chalk.gray(`Using existing AWS build at: ${path.relative(projectRoot, buildPath)}`));
+    } else {
+      // Look for the built Hono app
+      const entryPoint = path.join(standardBuildPath, 'index.js');
+      const srcEntryPoint = path.join(projectRoot, 'src', 'index.ts');
+      const appEntryPoint = path.join(projectRoot, 'src', 'app.ts');
+      
+      // Determine which entry point to use
+      let selectedEntryPoint: string;
+      if (fs.existsSync(entryPoint)) {
+        selectedEntryPoint = entryPoint;
+      } else if (fs.existsSync(appEntryPoint)) {
+        selectedEntryPoint = appEntryPoint;
+      } else if (fs.existsSync(srcEntryPoint)) {
+        selectedEntryPoint = srcEntryPoint;
+      } else {
+        throw new Error('No Hono entry point found. Expected dist/index.js or src/index.ts or src/app.ts');
+      }
+      
+      console.log(chalk.cyan('Preparing Hono app for AWS Lambda...'));
+      console.log(chalk.gray(`  Entry point: ${path.relative(projectRoot, selectedEntryPoint)}`));
+      
+      try {
+        const buildResult = await buildHonoForAws(
+          {
+            entryPoint: selectedEntryPoint,
+            out: '.nucel-build',
+            environment: config.environment,
+            bundle: true,
+            minify: true,
+            sourcemap: false,
+            external: [],
+            streaming: false,
+          },
+          {
+            bundle: true,
+            minify: true,
+            streaming: false,
+          }
+        );
+        
+        buildPath = buildResult.outDir;
+        console.log(chalk.green('✅ Hono app prepared for AWS Lambda'));
+      } catch (error) {
+        console.error(chalk.red('[Hono] Build failed:'), error);
+        throw error;
+      }
+    }
+    
+    if (!buildPath) {
+      throw new Error('No valid build found. Please run `npm run build` first.');
+    }
+    
+    // Deploy to AWS using Pulumi
+    return new HonoNucelAws(projectName, {
+      buildPath,
+      environment: config.environment,
+      lambda: {
+        memorySize: 512,
+        timeout: 15,
+        architecture: 'arm64',
+      },
+      tags: {
+        Framework: 'Hono',
+        ManagedBy: 'Nucel',
+        Project: projectName,
+        Environment: 'production',
+      },
+    });
+  };
+}

--- a/packages/cli/src/programs/index.ts
+++ b/packages/cli/src/programs/index.ts
@@ -1,3 +1,4 @@
 export { createNextJsProgram } from './nextjs.js';
 export { createSvelteKitProgram } from './sveltekit.js';
 export { createReactRouterProgram } from './react-router.js';
+export { createHonoProgram } from './hono.js';

--- a/packages/cli/src/utils/detect-framework.ts
+++ b/packages/cli/src/utils/detect-framework.ts
@@ -16,6 +16,7 @@ export async function detectFramework(): Promise<Framework> {
     ...packageJson.devDependencies,
   };
 
+  // Check each framework
   for (const [framework, config] of Object.entries(FRAMEWORK_CONFIGS)) {
     if (framework === 'unknown') continue;
     
@@ -24,11 +25,17 @@ export async function detectFramework(): Promise<Framework> {
     const hasDependency = config.dependencies.some(dep => deps[dep]);
     if (!hasDependency) continue;
     
-    const hasConfigFile = config.configFiles.some(configFile => 
-      fs.existsSync(path.join(projectRoot, configFile))
-    );
-    
-    if (hasConfigFile) {
+    // For frameworks with config files, check if they exist
+    if (config.configFiles && config.configFiles.length > 0) {
+      const hasConfigFile = config.configFiles.some(configFile => 
+        fs.existsSync(path.join(projectRoot, configFile))
+      );
+      
+      if (hasConfigFile) {
+        return frameworkKey;
+      }
+    } else {
+      // For frameworks without config files (like Hono), just having the dependency is enough
       return frameworkKey;
     }
   }

--- a/packages/database/src/db/schema.ts
+++ b/packages/database/src/db/schema.ts
@@ -4,7 +4,6 @@ import {
   timestamp,
   boolean,
   integer,
-  primaryKey,
   varchar,
   serial,
   bigint,

--- a/packages/hono-aws/README.md
+++ b/packages/hono-aws/README.md
@@ -1,0 +1,336 @@
+# @nucel.cloud/hono-aws
+
+A Hono.js adapter and Pulumi library for deploying Hono applications to AWS using Lambda, S3, and CloudFront.
+
+## Features
+
+- Serverless deployment with AWS Lambda
+- Global CDN with CloudFront
+- Static asset hosting with S3
+- Streaming response support
+- Edge-optimized performance
+- Infrastructure as Code with Pulumi
+- Vite-powered build system
+- TypeScript support
+
+## Installation
+
+```bash
+pnpm add @nucel.cloud/hono-aws
+```
+
+## Usage
+
+### 1. Create Your Hono App
+
+```typescript
+// src/index.ts
+import { Hono } from 'hono';
+import { cors } from 'hono/cors';
+import { logger } from 'hono/logger';
+
+const app = new Hono();
+
+app.use('*', logger());
+app.use('*', cors());
+
+app.get('/', (c) => {
+  return c.json({
+    message: 'Hello from Hono on AWS Lambda!',
+    timestamp: new Date().toISOString(),
+  });
+});
+
+app.get('/api/users/:id', (c) => {
+  const id = c.req.param('id');
+  return c.json({ user: { id, name: `User ${id}` } });
+});
+
+export default app;
+```
+
+### 2. Build Your App
+
+```bash
+pnpm build
+```
+
+### 3. Deploy with Pulumi
+
+Create a Pulumi program:
+
+```typescript
+import * as pulumi from "@pulumi/pulumi";
+import { HonoNucelAws } from "@nucel.cloud/hono-aws";
+
+const app = new HonoNucelAws("my-hono-app", {
+  buildPath: ".nucel-build",
+  
+  environment: {
+    NODE_ENV: "production",
+    API_URL: "https://api.example.com",
+  },
+  
+  lambda: {
+    memorySize: 512,
+    timeout: 15,
+    architecture: "arm64",
+  },
+  
+  domain: {
+    name: "api.example.com",
+    certificateArn: "arn:aws:acm:us-east-1:...:certificate/...",
+  },
+  
+  priceClass: "PriceClass_100",
+  
+  tags: {
+    Environment: "production",
+    Framework: "Hono",
+  },
+});
+
+export const url = app.url;
+export const distributionId = app.distributionId;
+export const bucketName = app.bucketName;
+export const functionArn = app.functionArn;
+```
+
+Deploy:
+
+```bash
+pulumi up
+```
+
+## Configuration
+
+### Build Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `entryPoint` | `string` | `src/index.ts` | Entry point for your Hono app |
+| `out` | `string` | `.nucel-build` | Output directory for build |
+| `minify` | `boolean` | `true` | Minify the output bundle |
+| `sourcemap` | `boolean` | `false` | Generate source maps |
+| `streaming` | `boolean` | `true` | Enable response streaming |
+| `external` | `string[]` | `[]` | External dependencies |
+
+### Deployment Options
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `buildPath` | `string` | Path to build output |
+| `environment` | `Record<string, string>` | Environment variables for Lambda |
+| `domain` | `{ name, certificateArn }` | Custom domain configuration |
+| `lambda` | `{ memorySize, timeout, architecture }` | Lambda configuration |
+| `priceClass` | `string` | CloudFront price class |
+| `tags` | `Record<string, string>` | AWS resource tags |
+| `streaming` | `boolean` | Enable Lambda response streaming |
+
+### Lambda Configuration
+
+```typescript
+lambda: {
+  memorySize: 512,      // Memory in MB (128-10240)
+  timeout: 15,          // Timeout in seconds (1-900)
+  architecture: "arm64", // "x86_64" or "arm64"
+}
+```
+
+## Architecture
+
+The deployment creates:
+
+1. **Lambda Function** - Runs your Hono application
+2. **Lambda Function URL** - Public HTTPS endpoint
+3. **S3 Bucket** - Stores static assets
+4. **CloudFront Distribution** - Global CDN with edge caching
+5. **IAM Roles** - Proper permissions for all services
+
+### Request Flow
+
+1. CloudFront receives request
+2. Static assets (`/static/*`, `*.js`, `*.css`) are served from S3
+3. API requests are forwarded to Lambda Function URL
+4. Lambda executes your Hono app
+5. Response is cached and delivered through CloudFront
+
+### Supported Features
+
+- **REST APIs** - Full support for RESTful endpoints
+- **Middleware** - All Hono middleware patterns
+- **Streaming Responses** - Server-sent events and streaming
+- **WebSocket** - Via Lambda Function URLs (preview)
+- **CORS** - Built-in CORS middleware support
+- **Request Validation** - Zod and other validators
+- **Authentication** - JWT, sessions, and custom auth
+- **File Uploads** - Multipart form data support
+
+## Advanced Usage
+
+### Streaming Responses
+
+Enable streaming for real-time data:
+
+```typescript
+// Enable in deployment
+const app = new HonoNucelAws("my-app", {
+  buildPath: ".nucel-build",
+  streaming: true, // Enable streaming
+  lambda: {
+    timeout: 300, // Longer timeout for streams
+  },
+});
+```
+
+```typescript
+// Use in your Hono app
+app.get('/api/stream', async (c) => {
+  c.header('Content-Type', 'text/event-stream');
+  c.header('Cache-Control', 'no-cache');
+  
+  const stream = c.env.streamText(async (stream) => {
+    for (let i = 0; i < 10; i++) {
+      await stream.write(`data: Event ${i}\n\n`);
+      await new Promise(r => setTimeout(r, 1000));
+    }
+  });
+  
+  return stream;
+});
+```
+
+### Custom Lambda Handler
+
+The adapter automatically creates an optimized Lambda handler that:
+- Converts Lambda events to Fetch API Request objects
+- Handles both Function URL and API Gateway formats
+- Supports streaming responses
+- Manages Lambda context properly
+
+### Environment Variables
+
+Pass environment variables to your Lambda function:
+
+```typescript
+environment: {
+  NODE_ENV: "production",
+  DATABASE_URL: process.env.DATABASE_URL,
+  JWT_SECRET: process.env.JWT_SECRET,
+}
+```
+
+### Static Assets
+
+Place static files in a `public` or `static` directory:
+
+```
+project/
+├── src/
+│   └── index.ts
+├── static/
+│   ├── logo.png
+│   └── styles.css
+└── package.json
+```
+
+These will be automatically deployed to S3 and served via CloudFront.
+
+### Custom Domain
+
+Configure a custom domain with ACM certificate:
+
+```typescript
+domain: {
+  name: "api.example.com",
+  certificateArn: "arn:aws:acm:us-east-1:123456789012:certificate/..."
+}
+```
+
+### CloudFront Price Classes
+
+- `PriceClass_100` - US, Canada, Europe
+- `PriceClass_200` - US, Canada, Europe, Asia, Middle East, Africa  
+- `PriceClass_All` - All edge locations worldwide
+
+## Middleware Examples
+
+### Authentication
+
+```typescript
+import { jwt } from 'hono/jwt';
+
+app.use('/api/*', jwt({
+  secret: process.env.JWT_SECRET,
+}));
+```
+
+### Rate Limiting
+
+```typescript
+import { rateLimiter } from 'hono-rate-limiter';
+
+app.use(rateLimiter({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  limit: 100, // 100 requests per window
+  standardHeaders: 'draft-6',
+  keyGenerator: (c) => c.req.header('x-forwarded-for'),
+}));
+```
+
+### Request Logging
+
+```typescript
+import { logger } from 'hono/logger';
+
+app.use('*', logger());
+```
+
+## Development
+
+```bash
+# Install dependencies
+pnpm install
+
+# Build the package
+pnpm build
+
+# Type check
+pnpm typecheck
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Cold starts**: Use `memorySize: 1024` or higher for better performance
+2. **Timeouts**: Increase `timeout` for heavy operations
+3. **CORS errors**: Ensure CORS middleware is applied before routes
+4. **Static assets 404**: Check CloudFront behaviors and S3 paths
+
+### Debugging
+
+Enable Lambda logging:
+```typescript
+environment: {
+  DEBUG: "true",
+  LOG_LEVEL: "debug",
+}
+```
+
+View CloudWatch logs:
+```bash
+aws logs tail /aws/lambda/[function-name] --follow
+```
+
+## Performance Tips
+
+1. **Use ARM architecture** - Better price/performance ratio
+2. **Enable CloudFront compression** - Reduces bandwidth
+3. **Set appropriate cache headers** - Leverage edge caching
+4. **Minimize cold starts** - Use higher memory allocation
+5. **Bundle dependencies** - Reduces package size
+
+## License
+
+MIT

--- a/packages/hono-aws/package.json
+++ b/packages/hono-aws/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@nucel.cloud/hono-aws",
+  "version": "0.1.0",
+  "description": "Hono.js adapter and Pulumi components for deploying to AWS Lambda, CloudFront, and S3",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./adapter": {
+      "types": "./dist/adapter/index.d.ts",
+      "import": "./dist/adapter/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "templates"
+  ],
+  "scripts": {
+    "build": "tsc && cp -r templates dist/",
+    "dev": "tsc --watch",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@pulumi/aws": "catalog:",
+    "@pulumi/pulumi": "catalog:",
+    "archiver": "catalog:",
+    "globby": "catalog:",
+    "mime-types": "catalog:",
+    "vite": "catalog:"
+  },
+  "devDependencies": {
+    "@repo/typescript-config": "workspace:*",
+    "@types/archiver": "catalog:",
+    "@types/mime-types": "catalog:",
+    "@types/node": "catalog:",
+    "hono": "^4.7.0",
+    "typescript": "catalog:"
+  },
+  "peerDependencies": {
+    "hono": "^4.0.0"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "hono",
+    "aws",
+    "lambda",
+    "serverless",
+    "pulumi",
+    "cloudfront",
+    "s3",
+    "edge",
+    "nucel"
+  ],
+  "author": "Nucel Cloud",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nucel-cloud/nucel"
+  },
+  "homepage": "https://nucel.cloud"
+}

--- a/packages/hono-aws/src/adapter/build.ts
+++ b/packages/hono-aws/src/adapter/build.ts
@@ -1,0 +1,229 @@
+import { writeFileSync, mkdirSync, existsSync, cpSync, rmSync, readFileSync, statSync, readdirSync, copyFileSync } from 'node:fs';
+import { join, dirname, resolve, extname } from 'node:path';
+import * as path from 'node:path';
+import { execSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { build as viteBuild, type InlineConfig } from 'vite';
+import type { HonoBuildConfig, HonoNucelAwsAdapterOptions } from '../types.js';
+
+// Get __dirname equivalent in ES modules
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/**
+ * Core build function that prepares Hono app for AWS Lambda
+ */
+export async function buildHonoForAws(
+  config: HonoBuildConfig,
+  options: HonoNucelAwsAdapterOptions = {}
+): Promise<{ serverDir: string; staticDir: string; outDir: string }> {
+  const {
+    out = '.nucel-build',
+    precompress = false,
+    envPrefix = '',
+    bundle = true,
+    minify = true,
+    sourcemap = false,
+    external = [],
+    staticDir: userStaticDir,
+    streaming = true,
+  } = options;
+  
+  console.log('🚀 Building Hono app for AWS Lambda deployment...');
+  
+  // Create output directories
+  const outDir = resolve(out);
+  const serverDir = join(outDir, 'server');
+  const staticDir = join(outDir, 'static');
+  
+  // Clean and create directories
+  if (existsSync(outDir)) {
+    rmSync(outDir, { recursive: true, force: true });
+  }
+  
+  mkdirSync(outDir, { recursive: true });
+  mkdirSync(serverDir, { recursive: true });
+  mkdirSync(staticDir, { recursive: true });
+  
+  // Copy static assets if provided
+  if (userStaticDir && existsSync(userStaticDir)) {
+    console.log('📦 Copying static assets...');
+    cpSync(userStaticDir, staticDir, { recursive: true });
+  }
+  
+  // Bundle the Hono application with Vite
+  console.log('📦 Building Hono application with Vite...');
+  
+  // First, build the Hono app with Vite
+  const viteConfig: InlineConfig = {
+    configFile: false,
+    mode: 'production',
+    root: dirname(config.entryPoint),
+    build: {
+      ssr: true,
+      outDir: serverDir,
+      emptyOutDir: false,
+      minify,
+      sourcemap,
+      rollupOptions: {
+        input: config.entryPoint,
+        output: {
+          entryFileNames: 'index.js',
+          format: 'es',
+        },
+        external: [
+          'hono',
+          ...external,
+          /^node:/,
+        ],
+      },
+      target: 'node22',
+    },
+    ssr: {
+      noExternal: true,
+      external: ['hono', ...external],
+    },
+    logLevel: 'info',
+  };
+  
+  try {
+    await viteBuild(viteConfig);
+    console.log('✅ Vite build completed successfully');
+  } catch (error) {
+    console.error('❌ Build failed:', error);
+    throw error;
+  }
+  
+  // Create handler
+  await createLambdaHandler(serverDir, streaming);
+  
+  // Setup dependencies
+  await setupLambdaDependencies(serverDir, config.entryPoint);
+  
+  // Create deployment metadata
+  const metadata = {
+    adapter: '@nucel.cloud/hono-aws',
+    timestamp: new Date().toISOString(),
+    bundle,
+    minify,
+    sourcemap,
+    streaming,
+    envPrefix,
+    entryPoint: config.entryPoint,
+    staticAssets: userStaticDir ? true : false,
+  };
+  
+  writeFileSync(
+    join(outDir, 'metadata.json'),
+    JSON.stringify(metadata, null, 2)
+  );
+  
+  console.log('✅ Build complete!');
+  console.log(`📁 Output directory: ${outDir}`);
+  console.log('   └── /server - Lambda function code');
+  console.log('   └── /static - Static assets for S3/CloudFront');
+  
+  return {
+    serverDir,
+    staticDir,
+    outDir,
+  };
+}
+
+/**
+ * Create the Lambda handler file
+ */
+async function createLambdaHandler(serverDir: string, streaming: boolean): Promise<void> {
+  // Copy the handler templates from the templates directory
+  const handlerTemplatePath = join(__dirname, '..', '..', 'templates', 'handler.js');
+  const lambdaHandlerTemplatePath = join(__dirname, '..', '..', 'templates', 'lambda-handler.js');
+  
+  const handlerPath = join(serverDir, 'handler.js');
+  const lambdaHandlerPath = join(serverDir, 'lambda-handler.js');
+  
+  // Copy lambda-handler.js (our custom Lambda adapter)
+  if (existsSync(lambdaHandlerTemplatePath)) {
+    copyFileSync(lambdaHandlerTemplatePath, lambdaHandlerPath);
+  } else {
+    throw new Error('Lambda handler template not found');
+  }
+  
+  // Copy main handler.js
+  if (existsSync(handlerTemplatePath)) {
+    let handlerContent = readFileSync(handlerTemplatePath, 'utf-8');
+    
+    // Set streaming environment variable if needed
+    if (streaming) {
+      handlerContent = `process.env.HONO_STREAMING = 'true';\n${handlerContent}`;
+    }
+    
+    writeFileSync(handlerPath, handlerContent);
+  } else {
+    throw new Error('Handler template not found');
+  }
+}
+
+/**
+ * Setup Lambda runtime dependencies
+ */
+async function setupLambdaDependencies(serverDir: string, entryPoint: string): Promise<void> {
+  // Read the app's package.json to get the actual dependencies
+  const appPackageJsonPath = resolve('package.json');
+  let appDependencies: Record<string, string> = {};
+  
+  if (existsSync(appPackageJsonPath)) {
+    const appPackageJson = JSON.parse(readFileSync(appPackageJsonPath, 'utf-8'));
+    // Copy only necessary runtime dependencies
+    const runtimeDeps = ['hono'];
+    appDependencies = Object.fromEntries(
+      Object.entries(appPackageJson.dependencies || {})
+        .filter(([key]) => runtimeDeps.includes(key) || key.startsWith('@aws-sdk/'))
+        .map(([key, value]) => [key, String(value)])
+    );
+  }
+  
+  // Create package.json for Lambda with minimal runtime dependencies
+  const lambdaPackageJson = {
+    type: 'module',
+    dependencies: {
+      'hono': '^4.7.0',
+      ...appDependencies,
+    }
+  };
+  
+  writeFileSync(
+    join(serverDir, 'package.json'),
+    JSON.stringify(lambdaPackageJson, null, 2)
+  );
+  
+  // Install production dependencies for Lambda runtime
+  console.log('📦 Installing Lambda runtime dependencies...');
+  try {
+    execSync('npm install --production --no-fund --no-audit', {
+      cwd: serverDir,
+      stdio: 'inherit'
+    });
+    console.log('✅ Lambda dependencies installed successfully');
+  } catch (error) {
+    console.error('❌ Failed to install dependencies:', error instanceof Error ? error.message : String(error));
+    throw new Error('Dependency installation failed - this is required for Lambda runtime');
+  }
+}
+
+/**
+ * Utility to get all files in a directory
+ */
+function getAllFiles(dirPath: string, arrayOfFiles: string[] = []): string[] {
+  const files = readdirSync(dirPath);
+  
+  files.forEach((file) => {
+    const filePath = join(dirPath, file);
+    if (statSync(filePath).isDirectory()) {
+      arrayOfFiles = getAllFiles(filePath, arrayOfFiles);
+    } else {
+      arrayOfFiles.push(filePath);
+    }
+  });
+  
+  return arrayOfFiles;
+}

--- a/packages/hono-aws/src/adapter/index.ts
+++ b/packages/hono-aws/src/adapter/index.ts
@@ -1,0 +1,49 @@
+import { buildHonoForAws } from './build.js';
+import type { HonoNucelAwsAdapterOptions } from '../types.js';
+
+/**
+ * Hono adapter for AWS Lambda deployment via Nucel
+ * 
+ * @param options - Adapter configuration options
+ * @returns Build function for Hono application
+ */
+export default function adapter(options: HonoNucelAwsAdapterOptions = {}) {
+  return {
+    name: '@nucel.cloud/hono-aws',
+    
+    async build(entryPoint: string) {
+      const {
+        out = '.nucel-build',
+        precompress = false,
+        envPrefix = '',
+        bundle = true,
+        minify = true,
+        sourcemap = false,
+        external = [],
+        staticDir,
+        streaming = false,
+      } = options;
+
+      return buildHonoForAws(
+        {
+          entryPoint,
+          out,
+          staticDir,
+          environment: process.env as Record<string, string>,
+          bundle,
+          minify,
+          sourcemap,
+          external,
+          streaming,
+        },
+        options
+      );
+    },
+  };
+}
+
+// Re-export build function for direct use
+export { buildHonoForAws } from './build.js';
+
+// Re-export types for convenience
+export type { HonoNucelAwsAdapterOptions, HonoBuildConfig } from '../types.js';

--- a/packages/hono-aws/src/components/cloudfront.ts
+++ b/packages/hono-aws/src/components/cloudfront.ts
@@ -1,0 +1,282 @@
+import * as aws from '@pulumi/aws';
+import * as pulumi from '@pulumi/pulumi';
+import { CACHE_POLICIES, ORIGIN_REQUEST_POLICIES, RESPONSE_HEADERS_POLICIES } from '../types.js';
+
+export interface CreateCloudFrontArgs {
+  name: string;
+  bucket: aws.s3.Bucket;
+  functionUrl: aws.lambda.FunctionUrl;
+  oai: aws.cloudfront.OriginAccessIdentity;
+  s3Objects: aws.s3.BucketObject[];
+  priceClass?: string;
+  domain?: {
+    name: string;
+    certificateArn: string;
+  };
+  tags?: Record<string, string>;
+  parent?: pulumi.ComponentResource;
+}
+
+export function createCloudFrontDistribution(args: CreateCloudFrontArgs) {
+  const {
+    name,
+    bucket,
+    functionUrl,
+    oai,
+    s3Objects,
+    priceClass = 'PriceClass_100',
+    domain,
+    tags = {},
+    parent
+  } = args;
+
+  // Create CloudFront distribution with performance optimizations
+  const distribution = new aws.cloudfront.Distribution(
+    `${name}-distribution`,
+    {
+      enabled: true,
+      httpVersion: 'http2and3', // Enable HTTP/2 and HTTP/3
+      priceClass,
+      isIpv6Enabled: true, // Enable IPv6
+      comment: `CloudFront distribution for ${name} Hono app`,
+      waitForDeployment: true,
+      
+      origins: [
+        // Lambda Function URL origin for API
+        {
+          domainName: functionUrl.functionUrl.apply(url => new URL(url).hostname),
+          originId: 'lambda-api',
+          customHeaders: [
+            {
+              name: 'x-forwarded-host',
+              value: functionUrl.functionUrl.apply(url => new URL(url).hostname),
+            },
+          ],
+          customOriginConfig: {
+            httpPort: 80,
+            httpsPort: 443,
+            originProtocolPolicy: 'https-only',
+            originSslProtocols: ['TLSv1.2'],
+            originReadTimeout: 30,
+            originKeepaliveTimeout: 5,
+          },
+        },
+        // S3 origin for static assets (if any)
+        {
+          domainName: bucket.bucketRegionalDomainName,
+          originId: 's3-static',
+          s3OriginConfig: {
+            originAccessIdentity: oai.cloudfrontAccessIdentityPath,
+          },
+        },
+      ],
+      
+      defaultCacheBehavior: {
+        targetOriginId: 'lambda-api',
+        viewerProtocolPolicy: 'redirect-to-https',
+        allowedMethods: ['GET', 'HEAD', 'OPTIONS', 'PUT', 'POST', 'PATCH', 'DELETE'],
+        cachedMethods: ['GET', 'HEAD', 'OPTIONS'],
+        compress: true,
+        // Use AWS managed policies for API endpoints
+        cachePolicyId: CACHE_POLICIES.CACHING_DISABLED, // Dynamic API content
+        originRequestPolicyId: ORIGIN_REQUEST_POLICIES.ALL_VIEWER_EXCEPT_HOST_HEADER,
+        responseHeadersPolicyId: RESPONSE_HEADERS_POLICIES.CORS_WITH_PREFLIGHT,
+      },
+      
+      orderedCacheBehaviors: [
+        // Static assets patterns
+        {
+          pathPattern: '/static/*',
+          targetOriginId: 's3-static',
+          viewerProtocolPolicy: 'redirect-to-https',
+          allowedMethods: ['GET', 'HEAD', 'OPTIONS'],
+          cachedMethods: ['GET', 'HEAD', 'OPTIONS'],
+          compress: true,
+          cachePolicyId: CACHE_POLICIES.CACHING_OPTIMIZED,
+          originRequestPolicyId: ORIGIN_REQUEST_POLICIES.CORS_S3_ORIGIN,
+        },
+        {
+          pathPattern: '/assets/*',
+          targetOriginId: 's3-static',
+          viewerProtocolPolicy: 'redirect-to-https',
+          allowedMethods: ['GET', 'HEAD', 'OPTIONS'],
+          cachedMethods: ['GET', 'HEAD', 'OPTIONS'],
+          compress: true,
+          cachePolicyId: CACHE_POLICIES.CACHING_OPTIMIZED,
+          originRequestPolicyId: ORIGIN_REQUEST_POLICIES.CORS_S3_ORIGIN,
+        },
+        // Common static file extensions
+        {
+          pathPattern: '*.css',
+          targetOriginId: 's3-static',
+          viewerProtocolPolicy: 'redirect-to-https',
+          allowedMethods: ['GET', 'HEAD', 'OPTIONS'],
+          cachedMethods: ['GET', 'HEAD', 'OPTIONS'],
+          compress: true,
+          cachePolicyId: CACHE_POLICIES.CACHING_OPTIMIZED,
+          originRequestPolicyId: ORIGIN_REQUEST_POLICIES.CORS_S3_ORIGIN,
+        },
+        {
+          pathPattern: '*.js',
+          targetOriginId: 's3-static',
+          viewerProtocolPolicy: 'redirect-to-https',
+          allowedMethods: ['GET', 'HEAD', 'OPTIONS'],
+          cachedMethods: ['GET', 'HEAD', 'OPTIONS'],
+          compress: true,
+          cachePolicyId: CACHE_POLICIES.CACHING_OPTIMIZED,
+          originRequestPolicyId: ORIGIN_REQUEST_POLICIES.CORS_S3_ORIGIN,
+        },
+        // Images
+        {
+          pathPattern: '*.jpg',
+          targetOriginId: 's3-static',
+          viewerProtocolPolicy: 'redirect-to-https',
+          allowedMethods: ['GET', 'HEAD'],
+          cachedMethods: ['GET', 'HEAD'],
+          compress: true,
+          cachePolicyId: CACHE_POLICIES.CACHING_OPTIMIZED,
+        },
+        {
+          pathPattern: '*.jpeg',
+          targetOriginId: 's3-static',
+          viewerProtocolPolicy: 'redirect-to-https',
+          allowedMethods: ['GET', 'HEAD'],
+          cachedMethods: ['GET', 'HEAD'],
+          compress: true,
+          cachePolicyId: CACHE_POLICIES.CACHING_OPTIMIZED,
+        },
+        {
+          pathPattern: '*.png',
+          targetOriginId: 's3-static',
+          viewerProtocolPolicy: 'redirect-to-https',
+          allowedMethods: ['GET', 'HEAD'],
+          cachedMethods: ['GET', 'HEAD'],
+          compress: true,
+          cachePolicyId: CACHE_POLICIES.CACHING_OPTIMIZED,
+        },
+        {
+          pathPattern: '*.gif',
+          targetOriginId: 's3-static',
+          viewerProtocolPolicy: 'redirect-to-https',
+          allowedMethods: ['GET', 'HEAD'],
+          cachedMethods: ['GET', 'HEAD'],
+          compress: true,
+          cachePolicyId: CACHE_POLICIES.CACHING_OPTIMIZED,
+        },
+        {
+          pathPattern: '*.webp',
+          targetOriginId: 's3-static',
+          viewerProtocolPolicy: 'redirect-to-https',
+          allowedMethods: ['GET', 'HEAD'],
+          cachedMethods: ['GET', 'HEAD'],
+          compress: true,
+          cachePolicyId: CACHE_POLICIES.CACHING_OPTIMIZED,
+        },
+        {
+          pathPattern: '*.svg',
+          targetOriginId: 's3-static',
+          viewerProtocolPolicy: 'redirect-to-https',
+          allowedMethods: ['GET', 'HEAD'],
+          cachedMethods: ['GET', 'HEAD'],
+          compress: true,
+          cachePolicyId: CACHE_POLICIES.CACHING_OPTIMIZED,
+        },
+        {
+          pathPattern: '*.ico',
+          targetOriginId: 's3-static',
+          viewerProtocolPolicy: 'redirect-to-https',
+          allowedMethods: ['GET', 'HEAD'],
+          cachedMethods: ['GET', 'HEAD'],
+          compress: true,
+          cachePolicyId: CACHE_POLICIES.CACHING_OPTIMIZED,
+        },
+        // Fonts
+        {
+          pathPattern: '*.woff',
+          targetOriginId: 's3-static',
+          viewerProtocolPolicy: 'redirect-to-https',
+          allowedMethods: ['GET', 'HEAD', 'OPTIONS'],
+          cachedMethods: ['GET', 'HEAD', 'OPTIONS'],
+          compress: true,
+          cachePolicyId: CACHE_POLICIES.CACHING_OPTIMIZED,
+          originRequestPolicyId: ORIGIN_REQUEST_POLICIES.CORS_S3_ORIGIN,
+        },
+        {
+          pathPattern: '*.woff2',
+          targetOriginId: 's3-static',
+          viewerProtocolPolicy: 'redirect-to-https',
+          allowedMethods: ['GET', 'HEAD', 'OPTIONS'],
+          cachedMethods: ['GET', 'HEAD', 'OPTIONS'],
+          compress: true,
+          cachePolicyId: CACHE_POLICIES.CACHING_OPTIMIZED,
+          originRequestPolicyId: ORIGIN_REQUEST_POLICIES.CORS_S3_ORIGIN,
+        },
+        {
+          pathPattern: '*.ttf',
+          targetOriginId: 's3-static',
+          viewerProtocolPolicy: 'redirect-to-https',
+          allowedMethods: ['GET', 'HEAD', 'OPTIONS'],
+          cachedMethods: ['GET', 'HEAD', 'OPTIONS'],
+          compress: true,
+          cachePolicyId: CACHE_POLICIES.CACHING_OPTIMIZED,
+          originRequestPolicyId: ORIGIN_REQUEST_POLICIES.CORS_S3_ORIGIN,
+        },
+        {
+          pathPattern: '*.otf',
+          targetOriginId: 's3-static',
+          viewerProtocolPolicy: 'redirect-to-https',
+          allowedMethods: ['GET', 'HEAD', 'OPTIONS'],
+          cachedMethods: ['GET', 'HEAD', 'OPTIONS'],
+          compress: true,
+          cachePolicyId: CACHE_POLICIES.CACHING_OPTIMIZED,
+          originRequestPolicyId: ORIGIN_REQUEST_POLICIES.CORS_S3_ORIGIN,
+        },
+      ],
+      
+      restrictions: {
+        geoRestriction: {
+          restrictionType: 'none',
+        },
+      },
+      
+      viewerCertificate: domain?.certificateArn
+        ? {
+            acmCertificateArn: domain.certificateArn,
+            sslSupportMethod: 'sni-only',
+            minimumProtocolVersion: 'TLSv1.2_2021',
+          }
+        : {
+            cloudfrontDefaultCertificate: true,
+          },
+      
+      aliases: domain ? [domain.name] : undefined,
+      
+      // Custom error pages for API
+      customErrorResponses: [
+        {
+          errorCode: 404,
+          responseCode: 404,
+          responsePagePath: '/404',
+          errorCachingMinTtl: 300,
+        },
+        {
+          errorCode: 403,
+          responseCode: 403,
+          responsePagePath: '/403',
+          errorCachingMinTtl: 300,
+        },
+        {
+          errorCode: 500,
+          responseCode: 500,
+          responsePagePath: '/500',
+          errorCachingMinTtl: 60,
+        },
+      ],
+      
+      tags,
+    },
+    { parent, dependsOn: s3Objects }
+  );
+
+  return distribution;
+}

--- a/packages/hono-aws/src/components/lambda.ts
+++ b/packages/hono-aws/src/components/lambda.ts
@@ -1,0 +1,146 @@
+import * as aws from '@pulumi/aws';
+import * as pulumi from '@pulumi/pulumi';
+import archiver from 'archiver';
+import { createWriteStream } from 'fs';
+import { join } from 'path';
+import type { LambdaConfig } from '../types.js';
+
+export interface CreateLambdaArgs {
+  name: string;
+  serverPath: string;
+  environment?: Record<string, pulumi.Input<string>>;
+  lambda?: LambdaConfig;
+  tags?: Record<string, string>;
+  parent?: pulumi.ComponentResource;
+  streaming?: boolean;
+}
+
+export interface LambdaResult {
+  function: aws.lambda.Function;
+  functionUrl: aws.lambda.FunctionUrl;
+}
+
+export function createLambda(args: CreateLambdaArgs): LambdaResult {
+  const {
+    name,
+    serverPath,
+    environment = {},
+    lambda = {},
+    tags = {},
+    parent,
+    streaming = true,
+  } = args;
+
+  const {
+    memorySize = 1024,
+    timeout = 30,
+    runtime = 'nodejs22.x',
+    reservedConcurrentExecutions,
+    architecture = 'arm64',
+  } = lambda;
+
+  // Create IAM role for Lambda
+  const lambdaRole = new aws.iam.Role(
+    `${name}-lambda-role`,
+    {
+      assumeRolePolicy: JSON.stringify({
+        Version: '2012-10-17',
+        Statement: [
+          {
+            Action: 'sts:AssumeRole',
+            Principal: {
+              Service: 'lambda.amazonaws.com',
+            },
+            Effect: 'Allow',
+          },
+        ],
+      }),
+      tags,
+    },
+    { parent }
+  );
+
+  // Attach basic execution policy
+  new aws.iam.RolePolicyAttachment(
+    `${name}-lambda-policy`,
+    {
+      role: lambdaRole.name,
+      policyArn: 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole',
+    },
+    { parent }
+  );
+
+  // Create archive from server directory
+  const archivePath = join(serverPath, '..', 'lambda.zip');
+  const archive = archiver('zip', { zlib: { level: 9 } });
+  const output = createWriteStream(archivePath);
+
+  const archivePromise = new Promise<string>((resolve, reject) => {
+    output.on('close', () => resolve(archivePath));
+    archive.on('error', reject);
+    
+    archive.pipe(output);
+    archive.directory(serverPath, false);
+    archive.finalize();
+  });
+
+  // Create Lambda function
+  const lambdaFunction = new aws.lambda.Function(
+    `${name}-function`,
+    {
+      code: new pulumi.asset.FileArchive(archivePath),
+      handler: 'handler.handler',
+      runtime,
+      role: lambdaRole.arn,
+      memorySize,
+      timeout,
+      architectures: [architecture],
+      environment: {
+        variables: {
+          NODE_ENV: 'production',
+          ...environment,
+          ...(streaming ? { HONO_STREAMING: 'true' } : {}),
+        },
+      },
+      reservedConcurrentExecutions,
+      tags,
+    },
+    { parent }
+  );
+
+  // Create Lambda Function URL with optional streaming
+  const functionUrl = new aws.lambda.FunctionUrl(
+    `${name}-function-url`,
+    {
+      functionName: lambdaFunction.name,
+      authorizationType: 'NONE',
+      cors: {
+        allowCredentials: true,
+        allowHeaders: ['*'],
+        allowMethods: ['*'],
+        allowOrigins: ['*'],
+        exposeHeaders: ['*'],
+        maxAge: 86400,
+      },
+      ...(streaming ? { invokeMode: 'RESPONSE_STREAM' } : {}),
+    },
+    { parent }
+  );
+
+  // Add permissions for Function URL
+  new aws.lambda.Permission(
+    `${name}-function-url-permission`,
+    {
+      action: 'lambda:InvokeFunctionUrl',
+      function: lambdaFunction.name,
+      principal: '*',
+      functionUrlAuthType: 'NONE',
+    },
+    { parent }
+  );
+
+  return {
+    function: lambdaFunction,
+    functionUrl,
+  };
+}

--- a/packages/hono-aws/src/components/s3.ts
+++ b/packages/hono-aws/src/components/s3.ts
@@ -1,0 +1,181 @@
+import * as aws from '@pulumi/aws';
+import * as pulumi from '@pulumi/pulumi';
+import { readdirSync, statSync } from 'fs';
+import { join } from 'path';
+import { lookup } from 'mime-types';
+
+export interface CreateS3BucketArgs {
+  name: string;
+  staticPath: string;
+  tags?: Record<string, string>;
+  parent?: pulumi.ComponentResource;
+}
+
+export interface S3Result {
+  bucket: aws.s3.Bucket;
+  oai: aws.cloudfront.OriginAccessIdentity;
+  objects: aws.s3.BucketObject[];
+}
+
+export function createS3Bucket(args: CreateS3BucketArgs): S3Result {
+  const { name, staticPath, tags = {}, parent } = args;
+
+  const bucket = new aws.s3.Bucket(
+    `${name}-static-assets`,
+    {
+      acl: 'private',
+      versioning: {
+        enabled: false,
+      },
+      serverSideEncryptionConfiguration: {
+        rule: {
+          applyServerSideEncryptionByDefault: {
+            sseAlgorithm: 'AES256',
+          },
+        },
+      },
+      lifecycleRules: [
+        {
+          enabled: true,
+          expiration: {
+            days: 90,
+          },
+          noncurrentVersionExpiration: {
+            days: 30,
+          },
+        },
+      ],
+      tags,
+    },
+    { parent }
+  );
+
+  // Block public access
+  new aws.s3.BucketPublicAccessBlock(
+    `${name}-bucket-pab`,
+    {
+      bucket: bucket.id,
+      blockPublicAcls: true,
+      blockPublicPolicy: true,
+      ignorePublicAcls: true,
+      restrictPublicBuckets: true,
+    },
+    { parent }
+  );
+
+  // Create Origin Access Identity for CloudFront
+  const oai = new aws.cloudfront.OriginAccessIdentity(
+    `${name}-oai`,
+    {
+      comment: `OAI for ${name} Hono app`,
+    },
+    { parent }
+  );
+
+  // Create bucket policy to allow CloudFront access
+  new aws.s3.BucketPolicy(
+    `${name}-bucket-policy`,
+    {
+      bucket: bucket.id,
+      policy: pulumi.all([bucket.id, oai.iamArn]).apply(([bucketId, oaiArn]) =>
+        JSON.stringify({
+          Version: '2012-10-17',
+          Statement: [
+            {
+              Effect: 'Allow',
+              Principal: {
+                AWS: oaiArn,
+              },
+              Action: 's3:GetObject',
+              Resource: `arn:aws:s3:::${bucketId}/*`,
+            },
+          ],
+        })
+      ),
+    },
+    { parent }
+  );
+
+  // Upload static files to S3
+  const objects: aws.s3.BucketObject[] = [];
+  
+  // Check if static directory exists and has files
+  let hasStaticFiles = false;
+  try {
+    const stats = statSync(staticPath);
+    if (stats.isDirectory()) {
+      const files = readdirSync(staticPath);
+      hasStaticFiles = files.length > 0;
+    }
+  } catch (error) {
+    // Static directory doesn't exist, which is fine for API-only apps
+    console.log('No static assets directory found - skipping static file upload');
+  }
+
+  if (hasStaticFiles) {
+    const uploadFiles = (dir: string, prefix = ''): void => {
+      const files = readdirSync(dir);
+      
+      for (const file of files) {
+        const filePath = join(dir, file);
+        const stats = statSync(filePath);
+        
+        if (stats.isDirectory()) {
+          uploadFiles(filePath, join(prefix, file));
+        } else {
+          const key = prefix ? join(prefix, file) : file;
+          const contentType = lookup(filePath) || 'application/octet-stream';
+          
+          const obj = new aws.s3.BucketObject(
+            `${name}-static-${key.replace(/[^a-zA-Z0-9-]/g, '-')}`,
+            {
+              bucket: bucket.id,
+              key,
+              source: new pulumi.asset.FileAsset(filePath),
+              contentType,
+              // Set cache control based on file type
+              cacheControl: getCacheControl(file),
+              tags,
+            },
+            { parent }
+          );
+          
+          objects.push(obj);
+        }
+      }
+    };
+    
+    uploadFiles(staticPath);
+  }
+
+  return {
+    bucket,
+    oai,
+    objects,
+  };
+}
+
+/**
+ * Get appropriate cache control header based on file type
+ */
+function getCacheControl(filename: string): string {
+  const ext = filename.split('.').pop()?.toLowerCase();
+  
+  // Immutable assets (with hash in filename)
+  if (filename.includes('.') && /\.[a-f0-9]{8,}\./.test(filename)) {
+    return 'public, max-age=31536000, immutable';
+  }
+  
+  // Images and fonts
+  if (['jpg', 'jpeg', 'png', 'gif', 'webp', 'svg', 'ico', 'woff', 'woff2', 'ttf', 'otf', 'eot'].includes(ext || '')) {
+    return 'public, max-age=2592000'; // 30 days
+  }
+  
+  // CSS and JS (without hash)
+  if (['css', 'js', 'mjs'].includes(ext || '')) {
+    return 'public, max-age=86400'; // 1 day
+  }
+  
+  // HTML and other files
+  return 'public, max-age=3600'; // 1 hour
+}

--- a/packages/hono-aws/src/index.ts
+++ b/packages/hono-aws/src/index.ts
@@ -1,0 +1,118 @@
+import * as pulumi from '@pulumi/pulumi';
+import { existsSync } from 'fs';
+import { join } from 'path';
+
+// Import types
+import { HonoNucelAwsArgs, DeploymentOutputs } from './types.js';
+
+// Import components
+import { createLambda } from './components/lambda.js';
+import { createS3Bucket } from './components/s3.js';
+import { createCloudFrontDistribution } from './components/cloudfront.js';
+
+/**
+ * Hono Nucel AWS Component
+ * 
+ * This component deploys a Hono application to AWS using:
+ * - Lambda for serverless API execution
+ * - S3 for static assets (optional)
+ * - CloudFront for CDN distribution
+ */
+export class HonoNucelAws extends pulumi.ComponentResource {
+  public readonly url: pulumi.Output<string>;
+  public readonly distributionId: pulumi.Output<string>;
+  public readonly bucketName: pulumi.Output<string>;
+  public readonly functionArn: pulumi.Output<string>;
+  
+  constructor(
+    name: string,
+    args: HonoNucelAwsArgs,
+    opts?: pulumi.ComponentResourceOptions
+  ) {
+    super('nucel:hono-aws', name, {}, opts);
+    
+    const { 
+      buildPath, 
+      environment = {}, 
+      lambda = {}, 
+      priceClass = 'PriceClass_100', 
+      domain,
+      tags = {},
+      streaming = false,
+      edge = false, // TODO: Implement Lambda@Edge support
+    } = args;
+    
+    // Validate build path
+    if (!existsSync(buildPath)) {
+      throw new Error(`Build path does not exist: ${buildPath}`);
+    }
+    
+    const serverPath = join(buildPath, 'server');
+    const staticPath = join(buildPath, 'static');
+    
+    if (!existsSync(serverPath)) {
+      throw new Error('Invalid build structure. Expected server/ directory.');
+    }
+    
+    // Create S3 bucket and upload static assets (if any)
+    const s3Result = createS3Bucket({
+      name,
+      staticPath,
+      tags,
+      parent: this,
+    });
+    
+    // Create Lambda function with optional streaming
+    const lambdaResult = createLambda({
+      name,
+      serverPath,
+      environment,
+      lambda,
+      tags,
+      parent: this,
+      streaming,
+    });
+    
+    // Create CloudFront distribution
+    const distribution = createCloudFrontDistribution({
+      name,
+      bucket: s3Result.bucket,
+      functionUrl: lambdaResult.functionUrl,
+      oai: s3Result.oai,
+      s3Objects: s3Result.objects,
+      priceClass,
+      domain,
+      tags,
+      parent: this,
+    });
+    
+    // Set outputs
+    this.url = distribution.domainName.apply(domain => `https://${domain}`);
+    this.distributionId = distribution.id;
+    this.bucketName = s3Result.bucket.id;
+    this.functionArn = lambdaResult.function.arn;
+    
+    this.registerOutputs({
+      url: this.url,
+      distributionId: this.distributionId,
+      bucketName: this.bucketName,
+      functionArn: this.functionArn,
+    });
+  }
+}
+
+// Re-export types for convenience
+export type { HonoNucelAwsArgs, HonoBuildConfig, HonoNucelAwsAdapterOptions } from './types.js';
+export type { LambdaConfig, DomainConfig } from './types.js';
+
+// Also export the adapter
+export { default as adapter } from './adapter/index.js';
+
+// Export a helper to create Hono AWS deployment
+export function createHonoAwsDeployment(
+  name: string,
+  args: HonoNucelAwsArgs,
+  opts?: pulumi.ComponentResourceOptions
+): HonoNucelAws {
+  return new HonoNucelAws(name, args, opts);
+}

--- a/packages/hono-aws/src/types.ts
+++ b/packages/hono-aws/src/types.ts
@@ -1,0 +1,249 @@
+import * as pulumi from '@pulumi/pulumi';
+
+/**
+ * Hono Nucel AWS Component configuration
+ */
+export interface HonoNucelAwsArgs {
+  /**
+   * Path to the built Hono application
+   */
+  buildPath: string;
+  
+  /**
+   * Environment variables for the Lambda function
+   */
+  environment?: Record<string, pulumi.Input<string>>;
+  
+  /**
+   * Lambda configuration
+   */
+  lambda?: LambdaConfig;
+  
+  /**
+   * CloudFront price class
+   * @default "PriceClass_100"
+   */
+  priceClass?: string;
+  
+  /**
+   * Custom domain configuration
+   */
+  domain?: DomainConfig;
+  
+  /**
+   * Resource tags
+   */
+  tags?: Record<string, string>;
+
+  /**
+   * Enable response streaming for Lambda
+   * @default false
+   */
+  streaming?: boolean;
+
+  /**
+   * Enable Lambda@Edge deployment
+   * @default false
+   */
+  edge?: boolean;
+}
+
+/**
+ * Lambda configuration options
+ */
+export interface LambdaConfig {
+  /**
+   * Memory size in MB
+   * @default 1024
+   */
+  memorySize?: number;
+  
+  /**
+   * Timeout in seconds
+   * @default 30
+   */
+  timeout?: number;
+  
+  /**
+   * Runtime version
+   * @default "nodejs22.x"
+   */
+  runtime?: string;
+  
+  /**
+   * Reserved concurrent executions
+   */
+  reservedConcurrentExecutions?: number;
+
+  /**
+   * Architecture
+   * @default "arm64"
+   */
+  architecture?: 'x86_64' | 'arm64';
+}
+
+/**
+ * Domain configuration
+ */
+export interface DomainConfig {
+  /**
+   * Domain name
+   */
+  name: string;
+  
+  /**
+   * ACM certificate ARN
+   */
+  certificateArn: string;
+  
+  /**
+   * Route53 hosted zone ID
+   */
+  hostedZoneId?: string;
+}
+
+/**
+ * Hono adapter configuration
+ */
+export interface HonoNucelAwsAdapterOptions {
+  /**
+   * Output directory
+   * @default ".nucel-build"
+   */
+  out?: string;
+  
+  /**
+   * Precompress static assets
+   * @default false
+   */
+  precompress?: boolean;
+  
+  /**
+   * Environment variable prefix to include
+   * @default ""
+   */
+  envPrefix?: string;
+  
+  /**
+   * Bundle the application with esbuild
+   * @default true
+   */
+  bundle?: boolean;
+
+  /**
+   * Minify the bundled code
+   * @default true
+   */
+  minify?: boolean;
+
+  /**
+   * Generate source maps
+   * @default false
+   */
+  sourcemap?: boolean;
+
+  /**
+   * External packages to exclude from bundling
+   * @default []
+   */
+  external?: string[];
+
+  /**
+   * Static assets directory to copy
+   */
+  staticDir?: string;
+
+  /**
+   * Enable response streaming
+   * @default false
+   */
+  streaming?: boolean;
+}
+
+/**
+ * Build configuration for Hono
+ */
+export interface HonoBuildConfig {
+  /**
+   * Path to the Hono application entry file
+   */
+  entryPoint: string;
+  
+  /**
+   * Output directory
+   */
+  out: string;
+  
+  /**
+   * Static assets directory
+   */
+  staticDir?: string;
+  
+  /**
+   * Environment variables to include
+   */
+  environment?: Record<string, string>;
+
+  /**
+   * Bundle options
+   */
+  bundle?: boolean;
+  minify?: boolean;
+  sourcemap?: boolean;
+  external?: string[];
+  streaming?: boolean;
+}
+
+/**
+ * Deployment outputs
+ */
+export interface DeploymentOutputs {
+  /**
+   * CloudFront distribution URL
+   */
+  url: pulumi.Output<string>;
+  
+  /**
+   * CloudFront distribution ID
+   */
+  distributionId: pulumi.Output<string>;
+  
+  /**
+   * S3 bucket name
+   */
+  bucketName: pulumi.Output<string>;
+  
+  /**
+   * Lambda function ARN
+   */
+  functionArn: pulumi.Output<string>;
+}
+
+/**
+ * AWS managed cache policies for CloudFront
+ */
+export const CACHE_POLICIES = {
+  CACHING_OPTIMIZED: '658327ea-f89d-4fab-a63d-7e88639e58f6',
+  CACHING_DISABLED: '4135ea2d-6df8-44a3-9df3-4b5a84be39ad',
+  CACHING_OPTIMIZED_FOR_UNCOMPRESSED_OBJECTS: 'b2884449-e4de-46a7-ac36-70bc7f1ddd6d',
+} as const;
+
+/**
+ * AWS managed origin request policies for CloudFront
+ */
+export const ORIGIN_REQUEST_POLICIES = {
+  ALL_VIEWER: '216adef6-5c7f-47e4-b989-5492eafa07d3',
+  ALL_VIEWER_EXCEPT_HOST_HEADER: 'b689b0a8-53d0-40ab-baf2-68738e2966ac',
+  CORS_S3_ORIGIN: '88a5eaf4-2fd4-4709-b370-b4c650ea3fcf',
+  CORS_CUSTOM_ORIGIN: '59781a5b-3903-41f3-afcb-af62929ccde1',
+  USER_AGENT_REFERER_HEADERS: 'acba4595-bd28-49b8-b9fe-13317c0390fa',
+} as const;
+
+/**
+ * AWS managed response headers policies for CloudFront
+ */
+export const RESPONSE_HEADERS_POLICIES = {
+  CORS_WITH_PREFLIGHT: '5cc3b908-e619-4b99-88e5-2cf7f45965bd',
+  CORS_WITH_PREFLIGHT_AND_SECURITY_HEADERS: 'eaab4381-ed33-4a86-88ca-d9558dc6cd63',
+  SECURITY_HEADERS: '67f7725c-6f97-4210-82d7-5512b31e9d03',
+} as const;

--- a/packages/hono-aws/templates/handler.js
+++ b/packages/hono-aws/templates/handler.js
@@ -1,0 +1,11 @@
+import { createHandler, createStreamHandler } from './lambda-handler.js';
+import * as app from './index.js';
+
+// Check if the app exports a Hono instance or handler directly
+const honoApp = app.app || app.default || app;
+
+// Determine if streaming is enabled based on environment variable
+const isStreaming = process.env.HONO_STREAMING === 'true';
+
+// Export the appropriate handler based on streaming configuration
+export const handler = isStreaming ? createStreamHandler(honoApp) : createHandler(honoApp);

--- a/packages/hono-aws/templates/lambda-handler.js
+++ b/packages/hono-aws/templates/lambda-handler.js
@@ -1,0 +1,196 @@
+/**
+ * AWS Lambda handler for Hono applications
+ * Converts Lambda events to Fetch API Request and Response
+ */
+
+// Helper to determine if content should be base64 encoded
+const isBase64Encoded = (contentType) => {
+  if (!contentType) return false;
+  
+  const textTypes = [
+    'text/',
+    'application/json',
+    'application/xml',
+    'application/javascript',
+    'application/x-www-form-urlencoded',
+  ];
+  
+  return !textTypes.some(type => contentType.includes(type));
+};
+
+const createRequest = (event, context) => {
+  const headers = new Headers();
+  
+  
+  if (event.headers) {
+    Object.entries(event.headers).forEach(([key, value]) => {
+      if (value) headers.set(key, value);
+    });
+  }
+  
+  if (event.multiValueHeaders) {
+    Object.entries(event.multiValueHeaders).forEach(([key, values]) => {
+      if (values) {
+        values.forEach(value => headers.append(key, value));
+      }
+    });
+  }
+  
+  let url;
+  const host = headers.get('host') || 'lambda.amazonaws.com';
+  const protocol = headers.get('x-forwarded-proto') || 'https';
+  
+  if (event.rawPath) {
+    // API Gateway v2 / Function URL
+    url = `${protocol}://${host}${event.rawPath}`;
+    if (event.rawQueryString) {
+      url += `?${event.rawQueryString}`;
+    }
+  } else {
+    throw new Error('Unable to determine request path');
+  }
+  
+  const method = event.requestContext?.http?.method || 
+                 event.requestContext?.httpMethod || 
+                 event.httpMethod || 
+                 'GET';
+  
+  let body = undefined;
+  if (event.body) {
+    if (event.isBase64Encoded) {
+      body = Buffer.from(event.body, 'base64');
+    } else {
+      body = event.body;
+    }
+  }
+  
+  const request = new Request(url, {
+    method,
+    headers,
+    body: body && method !== 'GET' && method !== 'HEAD' ? body : undefined,
+  });
+  
+  request.lambdaEvent = event;
+  request.lambdaContext = context;
+  
+  return request;
+};
+
+const createResult = async (response, event) => {
+  const headers = {};
+  const multiValueHeaders = {};
+  
+  // Process response headers
+  response.headers.forEach((value, key) => {
+    if (key.toLowerCase() === 'set-cookie') {
+      // Handle set-cookie as multi-value header
+      if (!multiValueHeaders['set-cookie']) {
+        multiValueHeaders['set-cookie'] = [];
+      }
+      multiValueHeaders['set-cookie'].push(value);
+    } else {
+      headers[key] = value;
+    }
+  });
+  
+  // Get response body
+  const contentType = response.headers.get('content-type') || '';
+  const isBase64 = isBase64Encoded(contentType);
+  
+  let body;
+  if (isBase64) {
+    const buffer = await response.arrayBuffer();
+    body = Buffer.from(buffer).toString('base64');
+  } else {
+    body = await response.text();
+  }
+  
+  
+    const result = {
+      statusCode: response.status,
+      headers,
+      body,
+      isBase64Encoded: isBase64,
+    };
+    
+    // Add cookies if present
+    if (multiValueHeaders['set-cookie']) {
+      result.cookies = multiValueHeaders['set-cookie'];
+    }
+    
+    return result;
+  
+};
+
+// Main handler function
+export const createHandler = (app) => {
+  return async (event, context) => {
+    try {
+      // Create Request from Lambda event
+      const request = createRequest(event, context);
+      
+      // Process request with Hono app
+      const response = await app.fetch(request, {
+        event,
+        context,
+      });
+      
+      // Convert Response to Lambda result
+      return await createResult(response, event);
+    } catch (error) {
+      console.error('Handler error:', error);
+      return {
+        statusCode: 500,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ 
+          message: 'Internal Server Error',
+          error: process.env.NODE_ENV === 'development' ? error.message : undefined
+        }),
+      };
+    }
+  };
+};
+
+// Streaming handler for response streaming
+export const createStreamHandler = (app) => {
+  return async (event, responseStream, context) => {
+    try {
+      const request = createRequest(event, context);
+      const response = await app.fetch(request, {
+        event,
+        context,
+      });
+      
+      // Set content type
+      const contentType = response.headers.get('content-type') || 'text/plain';
+      responseStream.setContentType(contentType);
+      
+      // Stream the response
+      if (response.body) {
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          
+          const chunk = decoder.decode(value, { stream: true });
+          responseStream.write(chunk);
+        }
+      } else {
+        const text = await response.text();
+        responseStream.write(text);
+      }
+      
+      responseStream.end();
+    } catch (error) {
+      console.error('Stream handler error:', error);
+      responseStream.setContentType('application/json');
+      responseStream.write(JSON.stringify({ 
+        message: 'Internal Server Error',
+        error: process.env.NODE_ENV === 'development' ? error.message : undefined
+      }));
+      responseStream.end();
+    }
+  };
+};

--- a/packages/hono-aws/tsconfig.json
+++ b/packages/hono-aws/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "@repo/typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "module": "ESNext",
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "templates"]
+}

--- a/packages/react-router-aws/package.json
+++ b/packages/react-router-aws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nucel.cloud/react-router-aws",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "React Router v7 adapter and Pulumi components for deploying to AWS Lambda, CloudFront, and S3",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/react-router-aws/src/components/cloudfront.ts
+++ b/packages/react-router-aws/src/components/cloudfront.ts
@@ -32,6 +32,7 @@ export function createCloudFrontDistribution(args: CreateCloudFrontArgs): aws.cl
     parent 
   } = args;
   
+  console.log(`${name}-distribution`)
   // Create CloudFront distribution with performance optimizations
   const distribution = new aws.cloudfront.Distribution(`${name}-distribution`, {
     enabled: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ catalogs:
     typescript:
       specifier: ^5.9.2
       version: 5.9.2
+    vite:
+      specifier: ^7.1.3
+      version: 7.1.3
     zod:
       specifier: ^4.1.5
       version: 4.1.5
@@ -230,6 +233,22 @@ importers:
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/ui@3.2.4)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.5)(yaml@2.8.0)
+
+  apps/hono:
+    dependencies:
+      hono:
+        specifier: ^4.7.0
+        version: 4.9.5
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.16.3
+      tsx:
+        specifier: ^4.20.0
+        version: 4.20.5
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.2
 
   apps/react-router:
     dependencies:
@@ -1061,6 +1080,46 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.3.0
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.2
+
+  packages/hono-aws:
+    dependencies:
+      '@pulumi/aws':
+        specifier: 'catalog:'
+        version: 7.6.0(typescript@5.9.2)
+      '@pulumi/pulumi':
+        specifier: 'catalog:'
+        version: 3.192.0(typescript@5.9.2)
+      archiver:
+        specifier: 'catalog:'
+        version: 7.0.1
+      globby:
+        specifier: 'catalog:'
+        version: 14.1.0
+      mime-types:
+        specifier: 'catalog:'
+        version: 3.0.1
+      vite:
+        specifier: 'catalog:'
+        version: 7.1.3(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.5)(yaml@2.8.0)
+    devDependencies:
+      '@repo/typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      '@types/archiver':
+        specifier: 'catalog:'
+        version: 6.0.3
+      '@types/mime-types':
+        specifier: 'catalog:'
+        version: 3.0.1
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.3.0
+      hono:
+        specifier: ^4.7.0
+        version: 4.9.5
       typescript:
         specifier: 'catalog:'
         version: 5.9.2
@@ -1921,6 +1980,12 @@ packages:
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
     deprecated: 'Merged into tsx: https://tsx.is'
 
+  '@esbuild/aix-ppc64@0.24.2':
+    resolution: {integrity: sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.25.4':
     resolution: {integrity: sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q==}
     engines: {node: '>=18'}
@@ -1942,6 +2007,12 @@ packages:
   '@esbuild/android-arm64@0.18.20':
     resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.24.2':
+    resolution: {integrity: sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
@@ -1969,6 +2040,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.24.2':
+    resolution: {integrity: sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-arm@0.25.4':
     resolution: {integrity: sha512-QNdQEps7DfFwE3hXiU4BZeOV68HHzYwGd0Nthhd3uCkkEKK7/R6MTgM0P7H7FAs5pU/DIWsviMmEGxEoxIZ+ZQ==}
     engines: {node: '>=18'}
@@ -1990,6 +2067,12 @@ packages:
   '@esbuild/android-x64@0.18.20':
     resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.24.2':
+    resolution: {integrity: sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
@@ -2017,6 +2100,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.24.2':
+    resolution: {integrity: sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.25.4':
     resolution: {integrity: sha512-Y1giCfM4nlHDWEfSckMzeWNdQS31BQGs9/rouw6Ub91tkK79aIMTH3q9xHvzH8d0wDru5Ci0kWB8b3up/nl16g==}
     engines: {node: '>=18'}
@@ -2038,6 +2127,12 @@ packages:
   '@esbuild/darwin-x64@0.18.20':
     resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.24.2':
+    resolution: {integrity: sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
@@ -2065,6 +2160,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.24.2':
+    resolution: {integrity: sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.25.4':
     resolution: {integrity: sha512-yYq+39NlTRzU2XmoPW4l5Ifpl9fqSk0nAJYM/V/WUGPEFfek1epLHJIkTQM6bBs1swApjO5nWgvr843g6TjxuQ==}
     engines: {node: '>=18'}
@@ -2086,6 +2187,12 @@ packages:
   '@esbuild/freebsd-x64@0.18.20':
     resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.24.2':
+    resolution: {integrity: sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
@@ -2113,6 +2220,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.24.2':
+    resolution: {integrity: sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.25.4':
     resolution: {integrity: sha512-+89UsQTfXdmjIvZS6nUnOOLoXnkUTB9hR5QAeLrQdzOSWZvNSAXAtcRDHWtqAUtAmv7ZM1WPOOeSxDzzzMogiQ==}
     engines: {node: '>=18'}
@@ -2134,6 +2247,12 @@ packages:
   '@esbuild/linux-arm@0.18.20':
     resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
     engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.24.2':
+    resolution: {integrity: sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
@@ -2161,6 +2280,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.24.2':
+    resolution: {integrity: sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.25.4':
     resolution: {integrity: sha512-yTEjoapy8UP3rv8dB0ip3AfMpRbyhSN3+hY8mo/i4QXFeDxmiYbEKp3ZRjBKcOP862Ua4b1PDfwlvbuwY7hIGQ==}
     engines: {node: '>=18'}
@@ -2182,6 +2307,12 @@ packages:
   '@esbuild/linux-loong64@0.18.20':
     resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
     engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.24.2':
+    resolution: {integrity: sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
@@ -2209,6 +2340,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.24.2':
+    resolution: {integrity: sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.25.4':
     resolution: {integrity: sha512-IcvTlF9dtLrfL/M8WgNI/qJYBENP3ekgsHbYUIzEzq5XJzzVEV/fXY9WFPfEEXmu3ck2qJP8LG/p3Q8f7Zc2Xg==}
     engines: {node: '>=18'}
@@ -2230,6 +2367,12 @@ packages:
   '@esbuild/linux-ppc64@0.18.20':
     resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
     engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.24.2':
+    resolution: {integrity: sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
@@ -2257,6 +2400,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.24.2':
+    resolution: {integrity: sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.25.4':
     resolution: {integrity: sha512-i8JUDAufpz9jOzo4yIShCTcXzS07vEgWzyX3NH2G7LEFVgrLEhjwL3ajFE4fZI3I4ZgiM7JH3GQ7ReObROvSUA==}
     engines: {node: '>=18'}
@@ -2278,6 +2427,12 @@ packages:
   '@esbuild/linux-s390x@0.18.20':
     resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
     engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.24.2':
+    resolution: {integrity: sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
@@ -2305,6 +2460,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.24.2':
+    resolution: {integrity: sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.25.4':
     resolution: {integrity: sha512-6e0cvXwzOnVWJHq+mskP8DNSrKBr1bULBvnFLpc1KY+d+irZSgZ02TGse5FsafKS5jg2e4pbvK6TPXaF/A6+CA==}
     engines: {node: '>=18'}
@@ -2322,6 +2483,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
+
+  '@esbuild/netbsd-arm64@0.24.2':
+    resolution: {integrity: sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
 
   '@esbuild/netbsd-arm64@0.25.4':
     resolution: {integrity: sha512-vUnkBYxZW4hL/ie91hSqaSNjulOnYXE1VSLusnvHg2u3jewJBz3YzB9+oCw8DABeVqZGg94t9tyZFoHma8gWZQ==}
@@ -2347,6 +2514,12 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.24.2':
+    resolution: {integrity: sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.25.4':
     resolution: {integrity: sha512-XAg8pIQn5CzhOB8odIcAm42QsOfa98SBeKUdo4xa8OvX8LbMZqEtgeWE9P/Wxt7MlG2QqvjGths+nq48TrUiKw==}
     engines: {node: '>=18'}
@@ -2364,6 +2537,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.24.2':
+    resolution: {integrity: sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
 
   '@esbuild/openbsd-arm64@0.25.4':
     resolution: {integrity: sha512-Ct2WcFEANlFDtp1nVAXSNBPDxyU+j7+tId//iHXU2f/lN5AmO4zLyhDcpR5Cz1r08mVxzt3Jpyt4PmXQ1O6+7A==}
@@ -2386,6 +2565,12 @@ packages:
   '@esbuild/openbsd-x64@0.18.20':
     resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.24.2':
+    resolution: {integrity: sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
@@ -2425,6 +2610,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.24.2':
+    resolution: {integrity: sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.25.4':
     resolution: {integrity: sha512-Mw+tzy4pp6wZEK0+Lwr76pWLjrtjmJyUB23tHKqEDP74R3q95luY/bXqXZeYl4NYlvwOqoRKlInQialgCKy67Q==}
     engines: {node: '>=18'}
@@ -2446,6 +2637,12 @@ packages:
   '@esbuild/win32-arm64@0.18.20':
     resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.24.2':
+    resolution: {integrity: sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
@@ -2473,6 +2670,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.24.2':
+    resolution: {integrity: sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.25.4':
     resolution: {integrity: sha512-i1sW+1i+oWvQzSgfRcxxG2k4I9n3O9NRqy8U+uugaT2Dy7kLO9Y7wI72haOahxceMX8hZAzgGou1FhndRldxRg==}
     engines: {node: '>=18'}
@@ -2494,6 +2697,12 @@ packages:
   '@esbuild/win32-x64@0.18.20':
     resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.24.2':
+    resolution: {integrity: sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
@@ -6934,6 +7143,11 @@ packages:
   esbuild@0.18.20:
     resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
     engines: {node: '>=12'}
+    hasBin: true
+
+  esbuild@0.24.2:
+    resolution: {integrity: sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==}
+    engines: {node: '>=18'}
     hasBin: true
 
   esbuild@0.25.4:
@@ -12681,6 +12895,9 @@ snapshots:
       '@esbuild-kit/core-utils': 3.3.2
       get-tsconfig: 4.10.1
 
+  '@esbuild/aix-ppc64@0.24.2':
+    optional: true
+
   '@esbuild/aix-ppc64@0.25.4':
     optional: true
 
@@ -12691,6 +12908,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/android-arm64@0.24.2':
     optional: true
 
   '@esbuild/android-arm64@0.25.4':
@@ -12705,6 +12925,9 @@ snapshots:
   '@esbuild/android-arm@0.18.20':
     optional: true
 
+  '@esbuild/android-arm@0.24.2':
+    optional: true
+
   '@esbuild/android-arm@0.25.4':
     optional: true
 
@@ -12715,6 +12938,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-x64@0.18.20':
+    optional: true
+
+  '@esbuild/android-x64@0.24.2':
     optional: true
 
   '@esbuild/android-x64@0.25.4':
@@ -12729,6 +12955,9 @@ snapshots:
   '@esbuild/darwin-arm64@0.18.20':
     optional: true
 
+  '@esbuild/darwin-arm64@0.24.2':
+    optional: true
+
   '@esbuild/darwin-arm64@0.25.4':
     optional: true
 
@@ -12739,6 +12968,9 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-x64@0.18.20':
+    optional: true
+
+  '@esbuild/darwin-x64@0.24.2':
     optional: true
 
   '@esbuild/darwin-x64@0.25.4':
@@ -12753,6 +12985,9 @@ snapshots:
   '@esbuild/freebsd-arm64@0.18.20':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.24.2':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.25.4':
     optional: true
 
@@ -12763,6 +12998,9 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-x64@0.18.20':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.24.2':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.4':
@@ -12777,6 +13015,9 @@ snapshots:
   '@esbuild/linux-arm64@0.18.20':
     optional: true
 
+  '@esbuild/linux-arm64@0.24.2':
+    optional: true
+
   '@esbuild/linux-arm64@0.25.4':
     optional: true
 
@@ -12787,6 +13028,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm@0.18.20':
+    optional: true
+
+  '@esbuild/linux-arm@0.24.2':
     optional: true
 
   '@esbuild/linux-arm@0.25.4':
@@ -12801,6 +13045,9 @@ snapshots:
   '@esbuild/linux-ia32@0.18.20':
     optional: true
 
+  '@esbuild/linux-ia32@0.24.2':
+    optional: true
+
   '@esbuild/linux-ia32@0.25.4':
     optional: true
 
@@ -12811,6 +13058,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-loong64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-loong64@0.24.2':
     optional: true
 
   '@esbuild/linux-loong64@0.25.4':
@@ -12825,6 +13075,9 @@ snapshots:
   '@esbuild/linux-mips64el@0.18.20':
     optional: true
 
+  '@esbuild/linux-mips64el@0.24.2':
+    optional: true
+
   '@esbuild/linux-mips64el@0.25.4':
     optional: true
 
@@ -12835,6 +13088,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ppc64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.24.2':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.4':
@@ -12849,6 +13105,9 @@ snapshots:
   '@esbuild/linux-riscv64@0.18.20':
     optional: true
 
+  '@esbuild/linux-riscv64@0.24.2':
+    optional: true
+
   '@esbuild/linux-riscv64@0.25.4':
     optional: true
 
@@ -12859,6 +13118,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-s390x@0.18.20':
+    optional: true
+
+  '@esbuild/linux-s390x@0.24.2':
     optional: true
 
   '@esbuild/linux-s390x@0.25.4':
@@ -12873,6 +13135,9 @@ snapshots:
   '@esbuild/linux-x64@0.18.20':
     optional: true
 
+  '@esbuild/linux-x64@0.24.2':
+    optional: true
+
   '@esbuild/linux-x64@0.25.4':
     optional: true
 
@@ -12880,6 +13145,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-x64@0.25.9':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.24.2':
     optional: true
 
   '@esbuild/netbsd-arm64@0.25.4':
@@ -12894,6 +13162,9 @@ snapshots:
   '@esbuild/netbsd-x64@0.18.20':
     optional: true
 
+  '@esbuild/netbsd-x64@0.24.2':
+    optional: true
+
   '@esbuild/netbsd-x64@0.25.4':
     optional: true
 
@@ -12901,6 +13172,9 @@ snapshots:
     optional: true
 
   '@esbuild/netbsd-x64@0.25.9':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.24.2':
     optional: true
 
   '@esbuild/openbsd-arm64@0.25.4':
@@ -12913,6 +13187,9 @@ snapshots:
     optional: true
 
   '@esbuild/openbsd-x64@0.18.20':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.24.2':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.4':
@@ -12933,6 +13210,9 @@ snapshots:
   '@esbuild/sunos-x64@0.18.20':
     optional: true
 
+  '@esbuild/sunos-x64@0.24.2':
+    optional: true
+
   '@esbuild/sunos-x64@0.25.4':
     optional: true
 
@@ -12943,6 +13223,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/win32-arm64@0.24.2':
     optional: true
 
   '@esbuild/win32-arm64@0.25.4':
@@ -12957,6 +13240,9 @@ snapshots:
   '@esbuild/win32-ia32@0.18.20':
     optional: true
 
+  '@esbuild/win32-ia32@0.24.2':
+    optional: true
+
   '@esbuild/win32-ia32@0.25.4':
     optional: true
 
@@ -12967,6 +13253,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.18.20':
+    optional: true
+
+  '@esbuild/win32-x64@0.24.2':
     optional: true
 
   '@esbuild/win32-x64@0.25.4':
@@ -16175,8 +16464,8 @@ snapshots:
       '@storybook/theming': 8.6.14(storybook@8.6.14(prettier@3.6.2))
       better-opn: 3.0.2
       browser-assert: 1.2.1
-      esbuild: 0.25.9
-      esbuild-register: 3.6.0(esbuild@0.25.9)
+      esbuild: 0.24.2
+      esbuild-register: 3.6.0(esbuild@0.24.2)
       jsdoc-type-pratt-parser: 4.8.0
       process: 0.11.10
       recast: 0.23.11
@@ -18348,6 +18637,13 @@ snapshots:
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.2
 
+  esbuild-register@3.6.0(esbuild@0.24.2):
+    dependencies:
+      debug: 4.4.1
+      esbuild: 0.24.2
+    transitivePeerDependencies:
+      - supports-color
+
   esbuild-register@3.6.0(esbuild@0.25.9):
     dependencies:
       debug: 4.4.1
@@ -18379,6 +18675,34 @@ snapshots:
       '@esbuild/win32-arm64': 0.18.20
       '@esbuild/win32-ia32': 0.18.20
       '@esbuild/win32-x64': 0.18.20
+
+  esbuild@0.24.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.24.2
+      '@esbuild/android-arm': 0.24.2
+      '@esbuild/android-arm64': 0.24.2
+      '@esbuild/android-x64': 0.24.2
+      '@esbuild/darwin-arm64': 0.24.2
+      '@esbuild/darwin-x64': 0.24.2
+      '@esbuild/freebsd-arm64': 0.24.2
+      '@esbuild/freebsd-x64': 0.24.2
+      '@esbuild/linux-arm': 0.24.2
+      '@esbuild/linux-arm64': 0.24.2
+      '@esbuild/linux-ia32': 0.24.2
+      '@esbuild/linux-loong64': 0.24.2
+      '@esbuild/linux-mips64el': 0.24.2
+      '@esbuild/linux-ppc64': 0.24.2
+      '@esbuild/linux-riscv64': 0.24.2
+      '@esbuild/linux-s390x': 0.24.2
+      '@esbuild/linux-x64': 0.24.2
+      '@esbuild/netbsd-arm64': 0.24.2
+      '@esbuild/netbsd-x64': 0.24.2
+      '@esbuild/openbsd-arm64': 0.24.2
+      '@esbuild/openbsd-x64': 0.24.2
+      '@esbuild/sunos-x64': 0.24.2
+      '@esbuild/win32-arm64': 0.24.2
+      '@esbuild/win32-ia32': 0.24.2
+      '@esbuild/win32-x64': 0.24.2
 
   esbuild@0.25.4:
     optionalDependencies:


### PR DESCRIPTION
## Summary
- Complete Hono.js AWS adapter for serverless deployment to Lambda
- Vite-based build system with streaming enabled by default  
- Custom Lambda handler without external Hono AWS dependencies
- CloudFront CDN with S3 static asset hosting
- Full CLI integration with framework detection

## Implementation Details
- Created custom Lambda event-to-Request conversion
- Implemented Vite programmatic building following Hono patterns
- Added Pulumi infrastructure components (Lambda, S3, CloudFront)
- Streaming responses enabled by default
- Complete TypeScript support with proper type definitions

## Test Plan
- Deployed successfully to AWS Lambda
- Verified streaming responses work correctly
- Tested with example Hono application
- Framework detection works without config files